### PR TITLE
Changed the way full code tests are being generated - now the module …

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -70,6 +70,14 @@ module Moto
         exit 1
       end
 
+      # Requires custom initializer if provided by application that uses Moto
+      if File.exists?( "#{MotoApp::DIR}/lib/initializer.rb" )
+        require("#{Moto::DIR}/lib/initializer.rb")
+        require("#{MotoApp::DIR}/lib/initializer.rb")
+        initializer = MotoApp::Initializer.new(self)
+        initializer.init
+      end
+
       tg = TestGenerator.new(MotoApp::DIR)
       test_paths_absolute.each do |test_path|
         test_classes << tg.generate(test_path)

--- a/lib/runner.rb
+++ b/lib/runner.rb
@@ -56,12 +56,6 @@ module Moto
     end
 
     def run
-      if File.exists?( "#{MotoApp::DIR}/lib/initializer.rb" )
-        require("#{Moto::DIR}/lib/initializer.rb")
-        require("#{MotoApp::DIR}/lib/initializer.rb")
-        initializer = MotoApp::Initializer.new(self)
-        initializer.init
-      end
       @listeners.each { |l| l.start_run }
       @tests.each do |test|
         @thread_pool.schedule do

--- a/lib/test_generator.rb
+++ b/lib/test_generator.rb
@@ -46,16 +46,17 @@ module Moto
         generate_for_run_body(test_path_absolute, method_body)
       end
     end
-    
+
+    # Generates objects with tests that are supposed to be executed in this run.
     def generate_for_full_class_code(test_path_absolute)
       require test_path_absolute
-      class_name = test_path_absolute.gsub("#{MotoApp::DIR}/",'moto_app/').split('/')[0..-2].join('/').camelize
-      test_object = class_name.constantize.new
+      class_name = test_path_absolute.gsub("#{MotoApp::DIR}/",'moto_app/').camelize.chomp('.rb').constantize
+      test_object = class_name.new
       test_object.static_path = test_path_absolute
       test_object.evaled = false
-      test_object      
+      test_object
     end
-    
+
     def generate_for_run_body(test_path_absolute, method_body)
       base = Moto::Test
       base_class_string = method_body.match( /^#\s*BASE_CLASS:\s(\S+)/ )


### PR DESCRIPTION
…structure resembles the folder structure 1:1 (last node not omitted like previously).

Moved requiring custom initializer to cli from runner (now executed before tests are generated).
