### PR TITLE
test_generator - removed @environment, now uses Moto::Lib::Config.env…

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,14 +71,23 @@ When editing `page` classes the following methods are available:
 * `current_test` - reference to currently running test
 * `client('Website')` - access other client object instance for given class name.
 
-### Environments
-under construction
+### Environment
+
+* Environment specific constants for the application under test are stored in two types of files:
+* `config/environments/common.rb` -  constants common for all the environments
+* `config/environments/ENVNAME.rb` - constants specific for environment specified with -e ENVNAME when running moto
+*
+* Both types of files should contain just ruby hashes with keys and values. They will be automatically deep merged by
+* moto and can be accessed by `Moto::Lib::Config.environment_const(key)`
+*
+* Please refer to rdoc in appropriate class for further information.
 
 ### Configuration
-Configuration is defined on 2 levels:
 
-* Environment specific constants for the application under test stored in `config/const.yml`. Access by `context.const`
-* Configuration for the framework and project classes stored in `config/moto.rb`. Access by `context.runner.my_config`
+* Configuration for the framework and project classes stored in `config/moto.rb`.
+* File should contain only hash with appropriate key/value pairs.
+*
+* Access by `Moto::Lib::Config.moto`
 
 ### Creating your own `listener`
 under construction

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -77,7 +77,7 @@ module Moto
 
       test_reporter = Moto::Reporting::TestReporter.new(argv[:listeners], argv[:name])
 
-      runner = Moto::Runner::TestRunner.new(test_paths_absolute, argv[:environments], test_reporter)
+      runner = Moto::Runner::TestRunner.new(test_paths_absolute, test_reporter)
       runner.run
     end
 

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -1,15 +1,40 @@
+require 'active_support'
+
 module Moto
   module Lib
     class Config
 
+      # @return [String] String representing the name of the current environment
+      def self.environment
+        @@environment
+      end
+
+      # @param [String] environment Sets a string that will represent environment in configuration, on which
+      #                             various settings will depend, for example env. constants
+      def self.environment=(environment)
+        @@environment = environment
+      end
+
+      # Loads configuration for whole test run and files responsible for environmental constants.
       def self.load_configuration
         if File.exists? "#{MotoApp::DIR}/config/moto.rb"
           @@moto = eval(File.read("#{MotoApp::DIR}/config/moto.rb"))
 
-          @@env_consts = {}
-          Dir.glob('config/*.yml').each do |f|
-            @@env_consts.deep_merge! YAML.load_file(f)
+          # Try reading constants that are common for all environments
+          begin
+            common_constants = eval(File.read('config/environments/common.rb'))
+          rescue
+            common_constants = {}
           end
+
+          # Try reading constants specific to current environment
+          begin
+            environment_constants = eval(File.read("config/environments/#{@@environment}.rb"))
+          rescue
+            environment_constants = {}
+          end
+
+          @@env_consts = common_constants.deep_merge(environment_constants)
 
         else
           raise "Config file (config/moto.rb) not present.\nDoes current working directory contain Moto application?"
@@ -26,23 +51,18 @@ module Moto
       # @return [String] Value of the key
       def self.environment_const(key)
         key = key.to_s
-        env = Thread.current['test_environment']
-
-        if env != :__default
-          key = "#{env.to_s}.#{key}"
-        end
 
         code = if key.include? '.'
-                 "@@env_consts#{key.split('.').map { |a| "['#{a}']" }.join('')}"
+                 "@@env_consts#{key.split('.').map { |a| "[:#{a}]" }.join('')}"
                else
-                 "@@env_consts['#{key}']"
+                 "@@env_consts[:#{key}]"
                end
 
         begin
-          value = eval code
+          value = eval(code)
           raise if value.nil?
         rescue
-          raise "There is no const defined for key: #{key}. Environment: #{ (env == :__default) ? '<none>' : env }"
+          raise "There is no const defined for key: #{key}."
         end
 
         value

--- a/lib/parser.rb
+++ b/lib/parser.rb
@@ -28,17 +28,12 @@ module Moto
     end
 
     def self.run_parse(argv)
-
-      Moto::Lib::Config.load_configuration
-
       require 'bundler/setup'
       Bundler.require
 
       # Default options
       options = {}
       options[:listeners] = []
-      # TODO Mandatory env var in app config
-      options[:environments] = []
       options[:name] = ''
 
       # Parse arguments
@@ -46,7 +41,7 @@ module Moto
         opts.on('-t', '--tests Tests', Array)              { |v| options[:tests ] = v }
         opts.on('-g', '--tags Tags', Array)                { |v| options[:tags ] = v }
         opts.on('-l', '--listeners Listeners', Array)      { |v| options[:listeners] = v }
-        opts.on('-e', '--environments Environment', Array) { |v| options[:environments] = v }
+        opts.on('-e', '--environment Environment')         { |v| options[:environment] = v }
         opts.on('-n', '--name Name')                       { |v| options[:name] = v }
         # opts.on('-f', '--config Config')                   { |v| options[:config].deep_merge!( eval( File.read(v) ) ) }
       end.parse!
@@ -55,10 +50,14 @@ module Moto
         options[:name] = evaluate_name(options[:tags], options[:tests])
       end
 
-      if Moto::Lib::Config.moto[:test_runner][:mandatory_environment] && options[:environments].empty?
-        puts 'Environment is mandatory for this project.'
+      if !options[:environment]
+        puts 'ERROR: Environment is mandatory.'
         exit 1
+      else
+        Moto::Lib::Config.environment = options[:environment]
+        Moto::Lib::Config.load_configuration
       end
+
 
       return options
     end
@@ -105,7 +104,7 @@ module Moto
                          For eg. Tests\Failure\Failure.rb should be passed as Tests::Failure
        -l, --listeners = Reporters to be used.
                          Defaults are Moto::Listeners::ConsoleDots, Moto::Listeners::JunitXml
-       -e, --environment etc etc
+       -e, --environment Mandatory environment. Environment constants and tests parametrized in certain way depend on this.
 
 
       moto generate:

--- a/lib/runner/test_provider.rb
+++ b/lib/runner/test_provider.rb
@@ -7,14 +7,13 @@ module Moto
     class TestProvider
 
       # @param [Array] test_paths_absolute
-      # @param [Array] environments Array
-      def initialize(test_paths_absolute, environments)
+      def initialize(test_paths_absolute)
         super()
         @test_repeats = Moto::Lib::Config.moto[:test_runner][:test_repeats]
         @current_test_repeat = 1
         @queue = Queue.new
         @test_paths_absolute = test_paths_absolute
-        @test_generator = TestGenerator.new(environments)
+        @test_generator = TestGenerator.new
       end
 
       # Use this to retrieve tests safely in multithreaded environment

--- a/lib/runner/test_runner.rb
+++ b/lib/runner/test_runner.rb
@@ -8,17 +8,16 @@ module Moto
       attr_reader :logger
       attr_reader :test_reporter
 
-      def initialize(test_paths_absolute, environments, test_reporter)
+      def initialize(test_paths_absolute, test_reporter)
         @test_paths_absolute = test_paths_absolute
         @test_reporter = test_reporter
 
         # TODO: initialize logger from config (yml or just ruby code)
         @logger = Logger.new(File.open("#{MotoApp::DIR}/moto.log", File::WRONLY | File::APPEND | File::CREAT))
-        @environments = environments.empty? ? environments << :__default : environments
       end
 
       def run
-        test_provider = TestProvider.new(@test_paths_absolute, @environments)
+        test_provider = TestProvider.new(@test_paths_absolute)
         threads_max = Moto::Lib::Config.moto[:test_runner][:thread_count] || 1
 
         # remove log/screenshot files from previous execution

--- a/lib/test/base.rb
+++ b/lib/test/base.rb
@@ -27,15 +27,15 @@ module Moto
       end
 
       # Initializes test to be executed with specified params and environment
-      def init(env, params, params_index, global_index)
-        @env = env
+      def init(params, params_index, global_index)
+        @env = Moto::Lib::Config.environment
         @params = params
         @name = generate_name(params_index, global_index)
 
         @status = Moto::Test::Status.new
         @status.name = @name
         @status.test_class_name = self.class.name
-        @status.env = @env
+        @status.env = Moto::Lib::Config.environment
         @status.params = @params
       end
 
@@ -45,15 +45,9 @@ module Moto
       def generate_name(params_index, global_index)
         simple_class_name = self.class.to_s.demodulize
 
-        if @env == :__default
-          return "#{simple_class_name}_#{global_index}" if @params.empty?
-          return "#{simple_class_name}_#{@params[:__name]}_#{global_index}" if @params.key?(:__name)
-          return "#{simple_class_name}_P#{params_index}_#{global_index}" unless @params.key?(:__name)
-        else
-          return "#{simple_class_name}_#{@env}_##{global_index}" if @params.empty?
-          return "#{simple_class_name}_#{@env}_#{@params[:__name]}_#{global_index}" if @params.key?(:__name)
-          return "#{simple_class_name}_#{@env}_P#{params_index}_#{global_index}" unless @params.key?(:__name)
-        end
+        return "#{simple_class_name}_#{@env}_##{global_index}" if @params.empty?
+        return "#{simple_class_name}_#{@env}_#{@params[:__name]}_#{global_index}" if @params.key?(:__name)
+        return "#{simple_class_name}_#{@env}_P#{params_index}_#{global_index}" unless @params.key?(:__name)
 
         self.class.to_s
       end
@@ -156,9 +150,9 @@ module Moto
         if !condition
           if evaled
             # -1 because of added method header in generated class
-            line_number = caller.select { |l| l.match(/\(eval\):\d*:in `run'/) }.first[/\d+/].to_i - 1
+            line_number = caller.select { |l| l.match(/\(eval\):\d*:in `run'/) }.first[/\d+/].to_i
           else
-            line_number = caller.select { |l| l.match(/#{static_path}:\d*:in `run'/) }.first[/\d+/].to_i - 1
+            line_number = caller.select { |l| l.match(/#{static_path}:\d*:in `run'/) }.first[/\d+/].to_i
           end
 
           status.log_failure("ASSERTION FAILED in line #{line_number}: #{message}")
@@ -166,7 +160,7 @@ module Moto
         end
       end
 
-      # Read a constants value from YML configuration files while taking the current execution environment into the account.
+      # Read a constants value from configuration files while taking the execution environment into the account.
       # @param [String] key Key to be searched for.
       # @return [String] Value of the key or nil if not found
       def const(key)

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Moto
-  VERSION = '0.0.51'
+  VERSION = '0.0.60'
 end


### PR DESCRIPTION
test_provider - removed env, since it was only needed for purpose of providing it further
test_runner - removed env, since it was only needed for purpose of providing it further
test/base -  env now uses Moto::Lib::Config.environment
cli - adjusted params
config - now takes environment and loads env consts based on that from RB files (config/environments/*.rb) instead of YAML files
parser - switched params to single string instead of array - multiple envs are no longer supported
version - 0.0.60
readme.md - updated information on environment and configuration
